### PR TITLE
According to javadoc Hook.post(EmbeddedServer) should be called befor…

### DIFF
--- a/junit-servers-core/src/main/java/com/github/mjeanroy/junit/servers/servers/AbstractEmbeddedServer.java
+++ b/junit-servers-core/src/main/java/com/github/mjeanroy/junit/servers/servers/AbstractEmbeddedServer.java
@@ -97,8 +97,8 @@ public abstract class AbstractEmbeddedServer<S extends Object, T extends Abstrac
 			synchronized (lock) {
 				if (status != ServerStatus.STOPPED) {
 					status = ServerStatus.STOPPING;
-					doStop();
 					execHooks(false);
+					doStop();
 					destroyEnvironment();
 					status = ServerStatus.STOPPED;
 				}


### PR DESCRIPTION
…e the server stops, but is called after. The execHooks(false) should be called before doStop().