### PR TITLE
Added missing WebInf and MetaInf configurations to embedded jetty

### DIFF
--- a/junit-servers-jetty/src/main/java/com/github/mjeanroy/junit/servers/jetty/EmbeddedJetty.java
+++ b/junit-servers-jetty/src/main/java/com/github/mjeanroy/junit/servers/jetty/EmbeddedJetty.java
@@ -36,7 +36,9 @@ import org.eclipse.jetty.util.resource.FileResource;
 import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.FragmentConfiguration;
 import org.eclipse.jetty.webapp.JettyWebXmlConfiguration;
+import org.eclipse.jetty.webapp.MetaInfConfiguration;
 import org.eclipse.jetty.webapp.WebAppContext;
+import org.eclipse.jetty.webapp.WebInfConfiguration;
 import org.eclipse.jetty.webapp.WebXmlConfiguration;
 
 import javax.servlet.ServletContext;
@@ -135,9 +137,11 @@ public class EmbeddedJetty extends AbstractEmbeddedServer<Server, EmbeddedJettyC
 		ctx.setBaseResource(newResource(webapp));
 
 		ctx.setConfigurations(new Configuration[]{
+			    new WebInfConfiguration(),
 				new WebXmlConfiguration(),
 				new AnnotationConfiguration(),
 				new JettyWebXmlConfiguration(),
+				new MetaInfConfiguration(),
 				new FragmentConfiguration(),
 		});
 


### PR DESCRIPTION
WebInfConfiguration and MetaInfConfiguration are included as defaults
https://github.com/eclipse/jetty.project/blob/jetty-9.3.12.v20160915/jetty-webapp/src/main/java/org/eclipse/jetty/webapp/WebAppContext.java#L102-L106
The FragmentConfiguration only works in conjunction with MetaInfConfiguration as that class does the actual scanning for fragments.