### PR TITLE
feat: allow preserving tomcat base directory on server stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,8 @@ Default configuration is:
 - A random port is used to start embedded tomcat.
 - Webapp is set to src/main/webapp (relative to root project)
 - Context path is set to "/"
-- Base directory is set to tomcat-work (relative to root project). Base directory will be deleted after tests.
+- Base directory is set to tomcat-work (relative to root project). By default, base directory will be deleted after tests
+  but when the configuration flag _keepBaseDir_ is set to _true_ the content of this directory will be preserved.
 - Naming is enable.
 
 ```java

--- a/junit-servers-tomcat/src/main/java/com/github/mjeanroy/junit/servers/tomcat/EmbeddedTomcat.java
+++ b/junit-servers-tomcat/src/main/java/com/github/mjeanroy/junit/servers/tomcat/EmbeddedTomcat.java
@@ -220,7 +220,9 @@ public class EmbeddedTomcat extends AbstractEmbeddedServer<Tomcat, EmbeddedTomca
 				context = null;
 			}
 
-			deleteDirectory(configuration.getBaseDir());
+			if (!configuration.isKeepBaseDir()) {
+				deleteDirectory(configuration.getBaseDir());
+			}
 		}
 		catch (Exception ex) {
 			throw new ServerStopException(ex);

--- a/junit-servers-tomcat/src/main/java/com/github/mjeanroy/junit/servers/tomcat/EmbeddedTomcatConfiguration.java
+++ b/junit-servers-tomcat/src/main/java/com/github/mjeanroy/junit/servers/tomcat/EmbeddedTomcatConfiguration.java
@@ -39,337 +39,337 @@ import com.github.mjeanroy.junit.servers.servers.configuration.AbstractConfigura
  */
 public class EmbeddedTomcatConfiguration extends AbstractConfiguration {
 
-    /**
-     * The default value for {@link Builder#classpath}.
-     */
-    private static final String DEFAULT_CLASSPATH = "./target/classes";
+	/**
+	 * The default value for {@link Builder#classpath}.
+	 */
+	private static final String DEFAULT_CLASSPATH = "./target/classes";
 
-    /**
-     * The default tomcat base directory.
-     */
-    private static final String DEFAULT_BASE_DIR = "./tomcat-work";
+	/**
+	 * The default tomcat base directory.
+	 */
+	private static final String DEFAULT_BASE_DIR = "./tomcat-work";
 
-    /**
-     * The default value for the {@link Builder#keepBaseDir} flag.
-     */
-    private static final boolean DEFAULT_KEEP_BASE_DIR = false;
+	/**
+	 * The default value for the {@link Builder#keepBaseDir} flag.
+	 */
+	private static final boolean DEFAULT_KEEP_BASE_DIR = false;
 
-    /**
-     * The default value for the {@link Builder#enableNaming} flag.
-     */
-    private static final boolean DEFAULT_ENABLE_NAMING = true;
+	/**
+	 * The default value for the {@link Builder#enableNaming} flag.
+	 */
+	private static final boolean DEFAULT_ENABLE_NAMING = true;
 
-    /**
-     * The default value for the {@link Builder#forceMetaInf} flag.
-     */
-    private static final boolean DEFAULT_FORCE_META_INF = true;
+	/**
+	 * The default value for the {@link Builder#forceMetaInf} flag.
+	 */
+	private static final boolean DEFAULT_FORCE_META_INF = true;
 
-    /**
-     * Get configuration builder.
-     *
-     * @return Builder.
-     */
-    public static Builder builder() {
-        return new Builder();
-    }
+	/**
+	 * Get configuration builder.
+	 *
+	 * @return Builder.
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
 
-    /**
-     * Get default configuration.
-     *
-     * @return Default configuration.
-     */
-    public static EmbeddedTomcatConfiguration defaultConfiguration() {
-        return new Builder().build();
-    }
+	/**
+	 * Get default configuration.
+	 *
+	 * @return Default configuration.
+	 */
+	public static EmbeddedTomcatConfiguration defaultConfiguration() {
+		return new Builder().build();
+	}
 
-    /**
-     * Tomcat Base Directory: this directory is where tomcat will store
-     * temporary files.
-     *
-     * @see Tomcat#setBaseDir(String)
-     */
-    private final String baseDir;
+	/**
+	 * Tomcat Base Directory: this directory is where tomcat will store
+	 * temporary files.
+	 *
+	 * @see Tomcat#setBaseDir(String)
+	 */
+	private final String baseDir;
 
-    /**
-     * Keep Tomcat Base Directory content on server stop.
-     */
-    private final boolean keepBaseDir;
+	/**
+	 * Keep Tomcat Base Directory content on server stop.
+	 */
+	private final boolean keepBaseDir;
 
-    /**
-     * Flag used to enable / disable naming.
-     * This is a flag to enables JNDI naming.
-     *
-     * @see Tomcat#enableNaming()
-     */
-    private final boolean enableNaming;
+	/**
+	 * Flag used to enable / disable naming.
+	 * This is a flag to enables JNDI naming.
+	 *
+	 * @see Tomcat#enableNaming()
+	 */
+	private final boolean enableNaming;
 
-    /**
-     * Flag used to force META-INF directory creation
-     * for additional classpath entries.
-     */
-    private final boolean forceMetaInf;
+	/**
+	 * Flag used to force META-INF directory creation
+	 * for additional classpath entries.
+	 */
+	private final boolean forceMetaInf;
 
-    /**
-     * Build new tomcat configuration.
-     *
-     * @param builder Builder object.
-     */
-    private EmbeddedTomcatConfiguration(Builder builder) {
-        super(builder);
-        this.baseDir = builder.getBaseDir();
-        this.keepBaseDir = builder.isKeepBaseDir();
-        this.enableNaming = builder.isEnableNaming();
-        this.forceMetaInf = builder.isForceMetaInf();
-    }
+	/**
+	 * Build new tomcat configuration.
+	 *
+	 * @param builder Builder object.
+	 */
+	private EmbeddedTomcatConfiguration(Builder builder) {
+		super(builder);
+		this.baseDir = builder.getBaseDir();
+		this.keepBaseDir = builder.isKeepBaseDir();
+		this.enableNaming = builder.isEnableNaming();
+		this.forceMetaInf = builder.isForceMetaInf();
+	}
 
-    /**
-     * Get {@link #baseDir}.
-     *
-     * @return {@link #baseDir}
-     */
-    public String getBaseDir() {
-        return baseDir;
-    }
+	/**
+	 * Get {@link #baseDir}.
+	 *
+	 * @return {@link #baseDir}
+	 */
+	public String getBaseDir() {
+		return baseDir;
+	}
 
-    /**
-     * Get current {@link #keepBaseDir} value.
-     *
-     * @return {@link #keepBaseDir}
-     */
-    public boolean isKeepBaseDir() {
-        return keepBaseDir;
-    }
+	/**
+	 * Get current {@link #keepBaseDir} value.
+	 *
+	 * @return {@link #keepBaseDir}
+	 */
+	public boolean isKeepBaseDir() {
+		return keepBaseDir;
+	}
 
-    /**
-     * Get {@link #enableNaming}.
-     *
-     * @return {@link #enableNaming}
-     */
-    public boolean isEnableNaming() {
-        return enableNaming;
-    }
+	/**
+	 * Get {@link #enableNaming}.
+	 *
+	 * @return {@link #enableNaming}
+	 */
+	public boolean isEnableNaming() {
+		return enableNaming;
+	}
 
-    /**
-     * Get {@link #forceMetaInf}.
-     *
-     * @return {@link #forceMetaInf}
-     */
-    public boolean isForceMetaInf() {
-        return forceMetaInf;
-    }
+	/**
+	 * Get {@link #forceMetaInf}.
+	 *
+	 * @return {@link #forceMetaInf}
+	 */
+	public boolean isForceMetaInf() {
+		return forceMetaInf;
+	}
 
-    @Override
-    public String toString() {
-        return ToStringBuilder.create(getClass())
-                .append("port", getPort())
-                .append("path", getPath())
-                .append("webapp", getWebapp())
-                .append("classpath", getClasspath())
-                .append("overrideDescriptor", getOverrideDescriptor())
-                .append("parentClasspath", getParentClasspath())
-                .append("baseDir", baseDir)
-                .append("keepBaseDir", keepBaseDir)
-                .append("enableNaming", enableNaming)
-                .append("forceMetaInf", forceMetaInf)
-                .build();
-    }
+	@Override
+	public String toString() {
+		return ToStringBuilder.create(getClass())
+				.append("port", getPort())
+				.append("path", getPath())
+				.append("webapp", getWebapp())
+				.append("classpath", getClasspath())
+				.append("overrideDescriptor", getOverrideDescriptor())
+				.append("parentClasspath", getParentClasspath())
+				.append("baseDir", baseDir)
+				.append("keepBaseDir", keepBaseDir)
+				.append("enableNaming", enableNaming)
+				.append("forceMetaInf", forceMetaInf)
+				.build();
+	}
 
-    @Override
-    public boolean equals(Object o) {
-        if (o == this) {
-            return true;
-        }
+	@Override
+	public boolean equals(Object o) {
+		if (o == this) {
+			return true;
+		}
 
-        if (o instanceof EmbeddedTomcatConfiguration) {
-            EmbeddedTomcatConfiguration c = (EmbeddedTomcatConfiguration) o;
-            return super.equals(c)
-                    && Objects.equals(baseDir, c.baseDir)
-                    && Objects.equals(keepBaseDir, c.keepBaseDir)
-                    && Objects.equals(enableNaming, c.enableNaming)
-                    && Objects.equals(forceMetaInf, c.forceMetaInf);
-        }
+		if (o instanceof EmbeddedTomcatConfiguration) {
+			EmbeddedTomcatConfiguration c = (EmbeddedTomcatConfiguration) o;
+			return super.equals(c)
+					&& Objects.equals(baseDir, c.baseDir)
+					&& Objects.equals(keepBaseDir, c.keepBaseDir)
+					&& Objects.equals(enableNaming, c.enableNaming)
+					&& Objects.equals(forceMetaInf, c.forceMetaInf);
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    @Override
-    protected boolean canEqual(Object o) {
-        return o instanceof EmbeddedTomcatConfiguration;
-    }
+	@Override
+	protected boolean canEqual(Object o) {
+		return o instanceof EmbeddedTomcatConfiguration;
+	}
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), baseDir, keepBaseDir, enableNaming, forceMetaInf);
-    }
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), baseDir, keepBaseDir, enableNaming, forceMetaInf);
+	}
 
-    /**
-     * Builder for {@link EmbeddedTomcatConfiguration}.
-     */
-    public static class Builder extends AbstractConfigurationBuilder<Builder, EmbeddedTomcatConfiguration> {
+	/**
+	 * Builder for {@link EmbeddedTomcatConfiguration}.
+	 */
+	public static class Builder extends AbstractConfigurationBuilder<Builder, EmbeddedTomcatConfiguration> {
 
-        /**
-         * The tomcat baseDir configuration: this directory is where tomcat will store
-         * temporary files.
-         * Default is {@link EmbeddedTomcatConfiguration#DEFAULT_BASE_DIR}.
-         *
-         * @see EmbeddedTomcatConfiguration#DEFAULT_BASE_DIR
-         * @see Tomcat#setBaseDir(String)
-         */
-        private String baseDir;
+		/**
+		 * The tomcat baseDir configuration: this directory is where tomcat will store
+		 * temporary files.
+		 * Default is {@link EmbeddedTomcatConfiguration#DEFAULT_BASE_DIR}.
+		 *
+		 * @see EmbeddedTomcatConfiguration#DEFAULT_BASE_DIR
+		 * @see Tomcat#setBaseDir(String)
+		 */
+		private String baseDir;
 
-        /**
-         * Keep tomcat base directory content on server stop.
-         * Default is {@link EmbeddedTomcatConfiguration#DEFAULT_KEEP_BASE_DIR}.
-         *
-         * @see EmbeddedTomcatConfiguration#DEFAULT_KEEP_BASE_DIR
-         */
-        private boolean keepBaseDir = DEFAULT_KEEP_BASE_DIR;
+		/**
+		 * Keep tomcat base directory content on server stop.
+		 * Default is {@link EmbeddedTomcatConfiguration#DEFAULT_KEEP_BASE_DIR}.
+		 *
+		 * @see EmbeddedTomcatConfiguration#DEFAULT_KEEP_BASE_DIR
+		 */
+		private boolean keepBaseDir = DEFAULT_KEEP_BASE_DIR;
 
-        /**
-         * Enable/Disable naming: this is a flag to enables JNDI naming.
-         * Default is {@link EmbeddedTomcatConfiguration#DEFAULT_ENABLE_NAMING}.
-         *
-         * @see EmbeddedTomcatConfiguration#DEFAULT_ENABLE_NAMING}
-         * @see Tomcat#enableNaming()
-         */
-        private boolean enableNaming;
+		/**
+		 * Enable/Disable naming: this is a flag to enables JNDI naming.
+		 * Default is {@link EmbeddedTomcatConfiguration#DEFAULT_ENABLE_NAMING}.
+		 *
+		 * @see EmbeddedTomcatConfiguration#DEFAULT_ENABLE_NAMING}
+		 * @see Tomcat#enableNaming()
+		 */
+		private boolean enableNaming;
 
-        /**
-         * Force the creation of the {@code META-INF} directory if it does not exist
-         * in the classpath.
-         */
-        private boolean forceMetaInf;
+		/**
+		 * Force the creation of the {@code META-INF} directory if it does not exist
+		 * in the classpath.
+		 */
+		private boolean forceMetaInf;
 
-        private Builder() {
-            baseDir = DEFAULT_BASE_DIR;
-            enableNaming = DEFAULT_ENABLE_NAMING;
-            forceMetaInf = DEFAULT_FORCE_META_INF;
+		private Builder() {
+			baseDir = DEFAULT_BASE_DIR;
+			enableNaming = DEFAULT_ENABLE_NAMING;
+			forceMetaInf = DEFAULT_FORCE_META_INF;
 
-            withClasspath(DEFAULT_CLASSPATH);
-        }
+			withClasspath(DEFAULT_CLASSPATH);
+		}
 
-        @Override
-        protected Builder self() {
-            return this;
-        }
+		@Override
+		protected Builder self() {
+			return this;
+		}
 
-        @Override
-        public EmbeddedTomcatConfiguration build() {
-            return new EmbeddedTomcatConfiguration(this);
-        }
+		@Override
+		public EmbeddedTomcatConfiguration build() {
+			return new EmbeddedTomcatConfiguration(this);
+		}
 
-        /**
-         * Get current {@link #baseDir} value.
-         *
-         * @return {@link #baseDir}
-         */
-        public String getBaseDir() {
-            return baseDir;
-        }
+		/**
+		 * Get current {@link #baseDir} value.
+		 *
+		 * @return {@link #baseDir}
+		 */
+		public String getBaseDir() {
+			return baseDir;
+		}
 
-        /**
-         * Get current {@link #keepBaseDir} value.
-         *
-         * @return {@link #keepBaseDir}
-         */
-        public boolean isKeepBaseDir() {
-            return keepBaseDir;
-        }
+		/**
+		 * Get current {@link #keepBaseDir} value.
+		 *
+		 * @return {@link #keepBaseDir}
+		 */
+		public boolean isKeepBaseDir() {
+			return keepBaseDir;
+		}
 
-        /**
-         * Get current {@link #enableNaming} value.
-         *
-         * @return {@link #enableNaming}
-         */
-        public boolean isEnableNaming() {
-            return enableNaming;
-        }
+		/**
+		 * Get current {@link #enableNaming} value.
+		 *
+		 * @return {@link #enableNaming}
+		 */
+		public boolean isEnableNaming() {
+			return enableNaming;
+		}
 
-        /**
-         * Get current {@link #forceMetaInf} value.
-         *
-         * @return {@link #forceMetaInf}
-         */
-        public boolean isForceMetaInf() {
-            return forceMetaInf;
-        }
+		/**
+		 * Get current {@link #forceMetaInf} value.
+		 *
+		 * @return {@link #forceMetaInf}
+		 */
+		public boolean isForceMetaInf() {
+			return forceMetaInf;
+		}
 
-        /**
-         * Change tomcat base directory.
-         *
-         * @param baseDir Base directory.
-         * @return this.
-         * @throws NullPointerException If {@code baseDir} is {@code null}.
-         */
-        public Builder withBaseDir(String baseDir) {
-            this.baseDir = notNull(baseDir, "baseDir");
-            return self();
-        }
+		/**
+		 * Change tomcat base directory.
+		 *
+		 * @param baseDir Base directory.
+		 * @return this.
+		 * @throws NullPointerException If {@code baseDir} is {@code null}.
+		 */
+		public Builder withBaseDir(String baseDir) {
+			this.baseDir = notNull(baseDir, "baseDir");
+			return self();
+		}
 
-        /**
-         * Keep tomcat base directory content on server stop.
-         *
-         * @return this.
-         */
-        public Builder keepBaseDir() {
-            this.keepBaseDir = true;
-            return self();
-        }
+		/**
+		 * Keep tomcat base directory content on server stop.
+		 *
+		 * @return this.
+		 */
+		public Builder keepBaseDir() {
+			this.keepBaseDir = true;
+			return self();
+		}
 
-        /**
-         * Delete tomcat base directory on server stop.
-         *
-         * @return this.
-         */
-        public Builder deleteBaseDir() {
-            this.keepBaseDir = false;
-            return self();
-        }
+		/**
+		 * Delete tomcat base directory on server stop.
+		 *
+		 * @return this.
+		 */
+		public Builder deleteBaseDir() {
+			this.keepBaseDir = false;
+			return self();
+		}
 
-        /**
-         * Enable naming (i.e enable JNDI) on tomcat server.
-         *
-         * @return this.
-         */
-        public Builder enableNaming() {
-            return toggleNaming(true);
-        }
+		/**
+		 * Enable naming (i.e enable JNDI) on tomcat server.
+		 *
+		 * @return this.
+		 */
+		public Builder enableNaming() {
+			return toggleNaming(true);
+		}
 
-        /**
-         * Disable naming (i.e disable JNDI) on tomcat server.
-         *
-         * @return this.
-         */
-        public Builder disableNaming() {
-            return toggleNaming(false);
-        }
+		/**
+		 * Disable naming (i.e disable JNDI) on tomcat server.
+		 *
+		 * @return this.
+		 */
+		public Builder disableNaming() {
+			return toggleNaming(false);
+		}
 
-        /**
-         * Enable META-INF creation.
-         *
-         * @return this.
-         */
-        public Builder enableForceMetaInf() {
-            return toggleMetaInf(true);
-        }
+		/**
+		 * Enable META-INF creation.
+		 *
+		 * @return this.
+		 */
+		public Builder enableForceMetaInf() {
+			return toggleMetaInf(true);
+		}
 
-        /**
-         * Disable META-INF creation.
-         *
-         * @return this.
-         */
-        public Builder disableForceMetaInf() {
-            return toggleMetaInf(false);
-        }
+		/**
+		 * Disable META-INF creation.
+		 *
+		 * @return this.
+		 */
+		public Builder disableForceMetaInf() {
+			return toggleMetaInf(false);
+		}
 
-        private Builder toggleNaming(boolean enableNaming) {
-            this.enableNaming = enableNaming;
-            return self();
-        }
+		private Builder toggleNaming(boolean enableNaming) {
+			this.enableNaming = enableNaming;
+			return self();
+		}
 
-        private Builder toggleMetaInf(boolean forceMetaInf) {
-            this.forceMetaInf = forceMetaInf;
-            return self();
-        }
-    }
+		private Builder toggleMetaInf(boolean forceMetaInf) {
+			this.forceMetaInf = forceMetaInf;
+			return self();
+		}
+	}
 }

--- a/junit-servers-tomcat/src/main/java/com/github/mjeanroy/junit/servers/tomcat/EmbeddedTomcatConfiguration.java
+++ b/junit-servers-tomcat/src/main/java/com/github/mjeanroy/junit/servers/tomcat/EmbeddedTomcatConfiguration.java
@@ -161,17 +161,17 @@ public class EmbeddedTomcatConfiguration extends AbstractConfiguration {
 	@Override
 	public String toString() {
 		return ToStringBuilder.create(getClass())
-				.append("port", getPort())
-				.append("path", getPath())
-				.append("webapp", getWebapp())
-				.append("classpath", getClasspath())
-				.append("overrideDescriptor", getOverrideDescriptor())
-				.append("parentClasspath", getParentClasspath())
-				.append("baseDir", baseDir)
-				.append("keepBaseDir", keepBaseDir)
-				.append("enableNaming", enableNaming)
-				.append("forceMetaInf", forceMetaInf)
-				.build();
+			.append("port", getPort())
+			.append("path", getPath())
+			.append("webapp", getWebapp())
+			.append("classpath", getClasspath())
+			.append("overrideDescriptor", getOverrideDescriptor())
+			.append("parentClasspath", getParentClasspath())
+			.append("baseDir", baseDir)
+			.append("keepBaseDir", keepBaseDir)
+			.append("enableNaming", enableNaming)
+			.append("forceMetaInf", forceMetaInf)
+			.build();
 	}
 
 	@Override

--- a/junit-servers-tomcat/src/main/java/com/github/mjeanroy/junit/servers/tomcat/EmbeddedTomcatConfiguration.java
+++ b/junit-servers-tomcat/src/main/java/com/github/mjeanroy/junit/servers/tomcat/EmbeddedTomcatConfiguration.java
@@ -39,278 +39,337 @@ import com.github.mjeanroy.junit.servers.servers.configuration.AbstractConfigura
  */
 public class EmbeddedTomcatConfiguration extends AbstractConfiguration {
 
-	/**
-	 * The default value for {@link Builder#classpath}.
-	 */
-	private static final String DEFAULT_CLASSPATH = "./target/classes";
+    /**
+     * The default value for {@link Builder#classpath}.
+     */
+    private static final String DEFAULT_CLASSPATH = "./target/classes";
 
-	/**
-	 * The default tomcat base directory.
-	 */
-	private static final String DEFAULT_BASE_DIR = "./tomcat-work";
+    /**
+     * The default tomcat base directory.
+     */
+    private static final String DEFAULT_BASE_DIR = "./tomcat-work";
 
-	/**
-	 * The default value for the {@link Builder#enableNaming} flag.
-	 */
-	private static final boolean DEFAULT_ENABLE_NAMING = true;
+    /**
+     * The default value for the {@link Builder#keepBaseDir} flag.
+     */
+    private static final boolean DEFAULT_KEEP_BASE_DIR = false;
 
-	/**
-	 * The default value for the {@link Builder#forceMetaInf} flag.
-	 */
-	private static final boolean DEFAULT_FORCE_META_INF = true;
+    /**
+     * The default value for the {@link Builder#enableNaming} flag.
+     */
+    private static final boolean DEFAULT_ENABLE_NAMING = true;
 
-	/**
-	 * Get configuration builder.
-	 *
-	 * @return Builder.
-	 */
-	public static Builder builder() {
-		return new Builder();
-	}
+    /**
+     * The default value for the {@link Builder#forceMetaInf} flag.
+     */
+    private static final boolean DEFAULT_FORCE_META_INF = true;
 
-	/**
-	 * Get default configuration.
-	 *
-	 * @return Default configuration.
-	 */
-	public static EmbeddedTomcatConfiguration defaultConfiguration() {
-		return new Builder().build();
-	}
+    /**
+     * Get configuration builder.
+     *
+     * @return Builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
 
-	/**
-	 * Tomcat Base Directory: this directory is where tomcat will store
-	 * temporary files.
-	 *
-	 * @see Tomcat#setBaseDir(String)
-	 */
-	private final String baseDir;
+    /**
+     * Get default configuration.
+     *
+     * @return Default configuration.
+     */
+    public static EmbeddedTomcatConfiguration defaultConfiguration() {
+        return new Builder().build();
+    }
 
-	/**
-	 * Flag used to enable / disable naming.
-	 * This is a flag to enables JNDI naming.
-	 *
-	 * @see Tomcat#enableNaming()
-	 */
-	private final boolean enableNaming;
+    /**
+     * Tomcat Base Directory: this directory is where tomcat will store
+     * temporary files.
+     *
+     * @see Tomcat#setBaseDir(String)
+     */
+    private final String baseDir;
 
-	/**
-	 * Flag used to force META-INF directory creation
-	 * for additional classpath entries.
-	 */
-	private final boolean forceMetaInf;
+    /**
+     * Keep Tomcat Base Directory content on server stop.
+     */
+    private final boolean keepBaseDir;
 
-	/**
-	 * Build new tomcat configuration.
-	 *
-	 * @param builder Builder object.
-	 */
-	private EmbeddedTomcatConfiguration(Builder builder) {
-		super(builder);
-		this.baseDir = builder.getBaseDir();
-		this.enableNaming = builder.isEnableNaming();
-		this.forceMetaInf = builder.isForceMetaInf();
-	}
+    /**
+     * Flag used to enable / disable naming.
+     * This is a flag to enables JNDI naming.
+     *
+     * @see Tomcat#enableNaming()
+     */
+    private final boolean enableNaming;
 
-	/**
-	 * Get {@link #baseDir}.
-	 *
-	 * @return {@link #baseDir}
-	 */
-	public String getBaseDir() {
-		return baseDir;
-	}
+    /**
+     * Flag used to force META-INF directory creation
+     * for additional classpath entries.
+     */
+    private final boolean forceMetaInf;
 
-	/**
-	 * Get {@link #enableNaming}.
-	 *
-	 * @return {@link #enableNaming}
-	 */
-	public boolean isEnableNaming() {
-		return enableNaming;
-	}
+    /**
+     * Build new tomcat configuration.
+     *
+     * @param builder Builder object.
+     */
+    private EmbeddedTomcatConfiguration(Builder builder) {
+        super(builder);
+        this.baseDir = builder.getBaseDir();
+        this.keepBaseDir = builder.isKeepBaseDir();
+        this.enableNaming = builder.isEnableNaming();
+        this.forceMetaInf = builder.isForceMetaInf();
+    }
 
-	/**
-	 * Get {@link #forceMetaInf}.
-	 *
-	 * @return {@link #forceMetaInf}
-	 */
-	public boolean isForceMetaInf() {
-		return forceMetaInf;
-	}
+    /**
+     * Get {@link #baseDir}.
+     *
+     * @return {@link #baseDir}
+     */
+    public String getBaseDir() {
+        return baseDir;
+    }
 
-	@Override
-	public String toString() {
-		return ToStringBuilder.create(getClass())
-			.append("port", getPort())
-			.append("path", getPath())
-			.append("webapp", getWebapp())
-			.append("classpath", getClasspath())
-			.append("overrideDescriptor", getOverrideDescriptor())
-			.append("parentClasspath", getParentClasspath())
-			.append("baseDir", baseDir)
-			.append("enableNaming", enableNaming)
-			.append("forceMetaInf", forceMetaInf)
-			.build();
-	}
+    /**
+     * Get current {@link #keepBaseDir} value.
+     *
+     * @return {@link #keepBaseDir}
+     */
+    public boolean isKeepBaseDir() {
+        return keepBaseDir;
+    }
 
-	@Override
-	public boolean equals(Object o) {
-		if (o == this) {
-			return true;
-		}
+    /**
+     * Get {@link #enableNaming}.
+     *
+     * @return {@link #enableNaming}
+     */
+    public boolean isEnableNaming() {
+        return enableNaming;
+    }
 
-		if (o instanceof EmbeddedTomcatConfiguration) {
-			EmbeddedTomcatConfiguration c = (EmbeddedTomcatConfiguration) o;
-			return super.equals(c)
-					&& Objects.equals(baseDir, c.baseDir)
-					&& Objects.equals(enableNaming, c.enableNaming)
-					&& Objects.equals(forceMetaInf, c.forceMetaInf);
-		}
+    /**
+     * Get {@link #forceMetaInf}.
+     *
+     * @return {@link #forceMetaInf}
+     */
+    public boolean isForceMetaInf() {
+        return forceMetaInf;
+    }
 
-		return false;
-	}
+    @Override
+    public String toString() {
+        return ToStringBuilder.create(getClass())
+                .append("port", getPort())
+                .append("path", getPath())
+                .append("webapp", getWebapp())
+                .append("classpath", getClasspath())
+                .append("overrideDescriptor", getOverrideDescriptor())
+                .append("parentClasspath", getParentClasspath())
+                .append("baseDir", baseDir)
+                .append("keepBaseDir", keepBaseDir)
+                .append("enableNaming", enableNaming)
+                .append("forceMetaInf", forceMetaInf)
+                .build();
+    }
 
-	@Override
-	protected boolean canEqual(Object o) {
-		return o instanceof EmbeddedTomcatConfiguration;
-	}
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
 
-	@Override
-	public int hashCode() {
-		return Objects.hash(super.hashCode(), baseDir, enableNaming, forceMetaInf);
-	}
+        if (o instanceof EmbeddedTomcatConfiguration) {
+            EmbeddedTomcatConfiguration c = (EmbeddedTomcatConfiguration) o;
+            return super.equals(c)
+                    && Objects.equals(baseDir, c.baseDir)
+                    && Objects.equals(keepBaseDir, c.keepBaseDir)
+                    && Objects.equals(enableNaming, c.enableNaming)
+                    && Objects.equals(forceMetaInf, c.forceMetaInf);
+        }
 
-	/**
-	 * Builder for {@link EmbeddedTomcatConfiguration}.
-	 */
-	public static class Builder extends AbstractConfigurationBuilder<Builder, EmbeddedTomcatConfiguration> {
+        return false;
+    }
 
-		/**
-		 * The tomcat baseDir configuration: this directory is where tomcat will store
-		 * temporary files.
-		 * Default is {@link EmbeddedTomcatConfiguration#DEFAULT_BASE_DIR}.
-		 *
-		 * @see EmbeddedTomcatConfiguration#DEFAULT_BASE_DIR
-		 * @see Tomcat#setBaseDir(String)
-		 */
-		private String baseDir;
+    @Override
+    protected boolean canEqual(Object o) {
+        return o instanceof EmbeddedTomcatConfiguration;
+    }
 
-		/**
-		 * Enable/Disable naming: this is a flag to enables JNDI naming.
-		 * Default is {@link EmbeddedTomcatConfiguration#DEFAULT_ENABLE_NAMING}.
-		 *
-		 * @see EmbeddedTomcatConfiguration#DEFAULT_ENABLE_NAMING}
-		 * @see Tomcat#enableNaming()
-		 */
-		private boolean enableNaming;
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), baseDir, keepBaseDir, enableNaming, forceMetaInf);
+    }
 
-		/**
-		 * Force the creation of the {@code META-INF} directory if it does not exist
-		 * in the classpath.
-		 */
-		private boolean forceMetaInf;
+    /**
+     * Builder for {@link EmbeddedTomcatConfiguration}.
+     */
+    public static class Builder extends AbstractConfigurationBuilder<Builder, EmbeddedTomcatConfiguration> {
 
-		private Builder() {
-			baseDir = DEFAULT_BASE_DIR;
-			enableNaming = DEFAULT_ENABLE_NAMING;
-			forceMetaInf = DEFAULT_FORCE_META_INF;
+        /**
+         * The tomcat baseDir configuration: this directory is where tomcat will store
+         * temporary files.
+         * Default is {@link EmbeddedTomcatConfiguration#DEFAULT_BASE_DIR}.
+         *
+         * @see EmbeddedTomcatConfiguration#DEFAULT_BASE_DIR
+         * @see Tomcat#setBaseDir(String)
+         */
+        private String baseDir;
 
-			withClasspath(DEFAULT_CLASSPATH);
-		}
+        /**
+         * Keep tomcat base directory content on server stop.
+         * Default is {@link EmbeddedTomcatConfiguration#DEFAULT_KEEP_BASE_DIR}.
+         *
+         * @see EmbeddedTomcatConfiguration#DEFAULT_KEEP_BASE_DIR
+         */
+        private boolean keepBaseDir = DEFAULT_KEEP_BASE_DIR;
 
-		@Override
-		protected Builder self() {
-			return this;
-		}
+        /**
+         * Enable/Disable naming: this is a flag to enables JNDI naming.
+         * Default is {@link EmbeddedTomcatConfiguration#DEFAULT_ENABLE_NAMING}.
+         *
+         * @see EmbeddedTomcatConfiguration#DEFAULT_ENABLE_NAMING}
+         * @see Tomcat#enableNaming()
+         */
+        private boolean enableNaming;
 
-		@Override
-		public EmbeddedTomcatConfiguration build() {
-			return new EmbeddedTomcatConfiguration(this);
-		}
+        /**
+         * Force the creation of the {@code META-INF} directory if it does not exist
+         * in the classpath.
+         */
+        private boolean forceMetaInf;
 
-		/**
-		 * Get current {@link #baseDir} value.
-		 *
-		 * @return {@link #baseDir}
-		 */
-		public String getBaseDir() {
-			return baseDir;
-		}
+        private Builder() {
+            baseDir = DEFAULT_BASE_DIR;
+            enableNaming = DEFAULT_ENABLE_NAMING;
+            forceMetaInf = DEFAULT_FORCE_META_INF;
 
-		/**
-		 * Get current {@link #enableNaming} value.
-		 *
-		 * @return {@link #enableNaming}
-		 */
-		public boolean isEnableNaming() {
-			return enableNaming;
-		}
+            withClasspath(DEFAULT_CLASSPATH);
+        }
 
-		/**
-		 * Get current {@link #forceMetaInf} value.
-		 *
-		 * @return {@link #forceMetaInf}
-		 */
-		public boolean isForceMetaInf() {
-			return forceMetaInf;
-		}
+        @Override
+        protected Builder self() {
+            return this;
+        }
 
-		/**
-		 * Change tomcat base directory.
-		 *
-		 * @param baseDir Base directory.
-		 * @return this.
-		 * @throws NullPointerException If {@code baseDir} is {@code null}.
-		 */
-		public Builder withBaseDir(String baseDir) {
-			this.baseDir = notNull(baseDir, "baseDir");
-			return self();
-		}
+        @Override
+        public EmbeddedTomcatConfiguration build() {
+            return new EmbeddedTomcatConfiguration(this);
+        }
 
-		/**
-		 * Enable naming (i.e enable JNDI) on tomcat server.
-		 *
-		 * @return this.
-		 */
-		public Builder enableNaming() {
-			return toggleNaming(true);
-		}
+        /**
+         * Get current {@link #baseDir} value.
+         *
+         * @return {@link #baseDir}
+         */
+        public String getBaseDir() {
+            return baseDir;
+        }
 
-		/**
-		 * Disable naming (i.e disable JNDI) on tomcat server.
-		 *
-		 * @return this.
-		 */
-		public Builder disableNaming() {
-			return toggleNaming(false);
-		}
+        /**
+         * Get current {@link #keepBaseDir} value.
+         *
+         * @return {@link #keepBaseDir}
+         */
+        public boolean isKeepBaseDir() {
+            return keepBaseDir;
+        }
 
-		/**
-		 * Enable META-INF creation.
-		 *
-		 * @return this.
-		 */
-		public Builder enableForceMetaInf() {
-			return toggleMetaInf(true);
-		}
+        /**
+         * Get current {@link #enableNaming} value.
+         *
+         * @return {@link #enableNaming}
+         */
+        public boolean isEnableNaming() {
+            return enableNaming;
+        }
 
-		/**
-		 * Disable META-INF creation.
-		 *
-		 * @return this.
-		 */
-		public Builder disableForceMetaInf() {
-			return toggleMetaInf(false);
-		}
+        /**
+         * Get current {@link #forceMetaInf} value.
+         *
+         * @return {@link #forceMetaInf}
+         */
+        public boolean isForceMetaInf() {
+            return forceMetaInf;
+        }
 
-		private Builder toggleNaming(boolean enableNaming) {
-			this.enableNaming = enableNaming;
-			return self();
-		}
+        /**
+         * Change tomcat base directory.
+         *
+         * @param baseDir Base directory.
+         * @return this.
+         * @throws NullPointerException If {@code baseDir} is {@code null}.
+         */
+        public Builder withBaseDir(String baseDir) {
+            this.baseDir = notNull(baseDir, "baseDir");
+            return self();
+        }
 
-		private Builder toggleMetaInf(boolean forceMetaInf) {
-			this.forceMetaInf = forceMetaInf;
-			return self();
-		}
-	}
+        /**
+         * Keep tomcat base directory content on server stop.
+         *
+         * @return this.
+         */
+        public Builder keepBaseDir() {
+            this.keepBaseDir = true;
+            return self();
+        }
+
+        /**
+         * Delete tomcat base directory on server stop.
+         *
+         * @return this.
+         */
+        public Builder deleteBaseDir() {
+            this.keepBaseDir = false;
+            return self();
+        }
+
+        /**
+         * Enable naming (i.e enable JNDI) on tomcat server.
+         *
+         * @return this.
+         */
+        public Builder enableNaming() {
+            return toggleNaming(true);
+        }
+
+        /**
+         * Disable naming (i.e disable JNDI) on tomcat server.
+         *
+         * @return this.
+         */
+        public Builder disableNaming() {
+            return toggleNaming(false);
+        }
+
+        /**
+         * Enable META-INF creation.
+         *
+         * @return this.
+         */
+        public Builder enableForceMetaInf() {
+            return toggleMetaInf(true);
+        }
+
+        /**
+         * Disable META-INF creation.
+         *
+         * @return this.
+         */
+        public Builder disableForceMetaInf() {
+            return toggleMetaInf(false);
+        }
+
+        private Builder toggleNaming(boolean enableNaming) {
+            this.enableNaming = enableNaming;
+            return self();
+        }
+
+        private Builder toggleMetaInf(boolean forceMetaInf) {
+            this.forceMetaInf = forceMetaInf;
+            return self();
+        }
+    }
 }

--- a/junit-servers-tomcat/src/test/java/com/github/mjeanroy/junit/servers/tomcat/EmbeddedTomcatConfigurationBuilderTest.java
+++ b/junit-servers-tomcat/src/test/java/com/github/mjeanroy/junit/servers/tomcat/EmbeddedTomcatConfigurationBuilderTest.java
@@ -53,6 +53,7 @@ public class EmbeddedTomcatConfigurationBuilderTest {
 		assertThat(builder.isForceMetaInf()).isTrue();
 		assertThat(builder.getClasspath()).isEqualTo("./target/classes");
 		assertThat(builder.getBaseDir()).isEqualTo("./tomcat-work");
+		assertThat(builder.isKeepBaseDir()).isFalse();
 	}
 
 	@Test
@@ -120,6 +121,22 @@ public class EmbeddedTomcatConfigurationBuilderTest {
 
 		assertThat(result).isSameAs(builder);
 		assertThat(result.getBaseDir()).isNotEqualTo(oldBaseDir).isEqualTo(newBaseDir);
+	}
+
+	@Test
+	public void it_should_keep_base_dir() {
+		EmbeddedTomcatConfiguration.Builder result = builder.keepBaseDir();
+
+		assertThat(result).isSameAs(builder);
+		assertThat(result.isKeepBaseDir()).isTrue();
+	}
+
+	@Test
+	public void it_should_delete_base_dir() {
+		EmbeddedTomcatConfiguration.Builder result = builder.deleteBaseDir();
+
+		assertThat(result).isSameAs(builder);
+		assertThat(result.isKeepBaseDir()).isFalse();
 	}
 
 	@Test

--- a/junit-servers-tomcat/src/test/java/com/github/mjeanroy/junit/servers/tomcat/EmbeddedTomcatConfigurationTest.java
+++ b/junit-servers-tomcat/src/test/java/com/github/mjeanroy/junit/servers/tomcat/EmbeddedTomcatConfigurationTest.java
@@ -42,6 +42,7 @@ public class EmbeddedTomcatConfigurationTest {
 		assertThat(result.getWebapp()).isEqualTo("src/main/webapp");
 		assertThat(result.isForceMetaInf()).isTrue();
 		assertThat(result.isEnableNaming()).isTrue();
+		assertThat(result.isKeepBaseDir()).isFalse();
 	}
 
 	@Test
@@ -58,6 +59,7 @@ public class EmbeddedTomcatConfigurationTest {
 				.withPath(path)
 				.disableNaming()
 				.disableForceMetaInf()
+				.keepBaseDir()
 				.build();
 
 		assertThat(result.getPort()).isEqualTo(port);
@@ -66,6 +68,7 @@ public class EmbeddedTomcatConfigurationTest {
 		assertThat(result.getWebapp()).isEqualTo(webapp);
 		assertThat(result.isForceMetaInf()).isFalse();
 		assertThat(result.isEnableNaming()).isFalse();
+		assertThat(result.isKeepBaseDir()).isTrue();
 	}
 
 	@Test
@@ -88,6 +91,7 @@ public class EmbeddedTomcatConfigurationTest {
 				"overrideDescriptor: null, " +
 				"parentClasspath: [], " +
 				"baseDir: \"./tomcat-work\", " +
+				"keepBaseDir: false, " +
 				"enableNaming: true, " +
 				"forceMetaInf: true" +
 			"}");

--- a/junit-servers-tomcat/src/test/java/com/github/mjeanroy/junit/servers/tomcat/EmbeddedTomcatTest.java
+++ b/junit-servers-tomcat/src/test/java/com/github/mjeanroy/junit/servers/tomcat/EmbeddedTomcatTest.java
@@ -98,6 +98,32 @@ public class EmbeddedTomcatTest {
 	}
 
 	@Test
+	public void it_should_delete_base_dir_on_stop() {
+		tomcat = new EmbeddedTomcat(defaultConfigurationBuilder().deleteBaseDir().build());
+		File baseDir = new File(tomcat.getConfiguration().getBaseDir());
+
+		assertThat(baseDir).exists();
+
+		tomcat.start();
+		tomcat.stop();
+
+		assertThat(baseDir).doesNotExist();
+	}
+
+	@Test
+	public void it_should_keep_base_dir_on_stop() {
+		tomcat = new EmbeddedTomcat(defaultConfigurationBuilder().keepBaseDir().build());
+		File baseDir = new File(tomcat.getConfiguration().getBaseDir());
+
+		assertThat(baseDir).exists();
+
+		tomcat.start();
+		tomcat.stop();
+
+		assertThat(baseDir).exists();
+	}
+
+	@Test
 	public void it_should_get_servlet_context() {
 		tomcat = new EmbeddedTomcat(defaultConfiguration());
 		tomcat.start();


### PR DESCRIPTION
Keeping content of the base directory can sometimes be handy,
for example when third party application packaged as war is required
by the server under test. In my case it is gitblit which is unpacked
by maven in generate test resources phase and then gitblit is started
via junit-servers for my application integration tests.
It is much more efficient to preserve tomcat directory between restarts
(even when some small housekeeping is necessary) than copying over
megabytes of jars to temporary directory between gitblit restarts.